### PR TITLE
chore: upgrade npm-check-updates to 22

### DIFF
--- a/.ncurc.major.mjs
+++ b/.ncurc.major.mjs
@@ -1,6 +1,6 @@
-const minorConfig = require('./.ncurc.minor.cjs');
+import minorConfig from './.ncurc.minor.mjs';
 
-module.exports = {
+export default {
   ...minorConfig,
   reject: [
     ...minorConfig.reject,

--- a/.ncurc.minor.mjs
+++ b/.ncurc.minor.mjs
@@ -1,6 +1,6 @@
-const patchConfig = require('./.ncurc.patch.cjs');
+import patchConfig from './.ncurc.patch.mjs';
 
-module.exports = {
+export default {
   ...patchConfig,
   reject: [...patchConfig.reject],
   target: 'minor',

--- a/.ncurc.patch.mjs
+++ b/.ncurc.patch.mjs
@@ -1,5 +1,4 @@
-module.exports = {
-  cooldown: 1, // 1 day
+export default {
   dep: ['dev', 'prod'],
   install: 'always',
   reject: [],

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "prettier": "prettier --write .",
     "e2e": "ng e2e",
     "test-update": "pnpm run --if-present lint && pnpm run --if-present test && pnpm run --if-present build && pnpm run --if-present lint-build && pnpm run --if-present test-build",
-    "update-patch": "npm-check-updates --configFileName .ncurc.patch.cjs",
-    "update-minor": "npm-check-updates --configFileName .ncurc.minor.cjs",
-    "update-major": "npm-check-updates --configFileName .ncurc.major.cjs"
+    "update-patch": "npm-check-updates --configFileName .ncurc.patch.mjs",
+    "update-minor": "npm-check-updates --configFileName .ncurc.minor.mjs",
+    "update-major": "npm-check-updates --configFileName .ncurc.major.mjs"
   },
   "private": true,
   "dependencies": {
@@ -70,7 +70,7 @@
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.1.0",
     "lint-staged": "15.5.2",
-    "npm-check-updates": "19.3.2",
+    "npm-check-updates": "22.2.9",
     "npm-run-all": "4.1.5",
     "prettier": "3.8.1",
     "protractor": "7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
         specifier: 15.5.2
         version: 15.5.2
       npm-check-updates:
-        specifier: 19.3.2
-        version: 19.3.2
+        specifier: 22.2.9
+        version: 22.2.9
       npm-run-all:
         specifier: 4.1.5
         version: 4.1.5
@@ -4643,9 +4643,9 @@ packages:
     resolution: {integrity: sha512-IxaQZDMsqfQ2Lz37VvyyEtKLe8FsRZuysmedy/N06TU1RyVppYKXrO4xIhR0F+7ubIBox6Q7nir6fQI3ej39iA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  npm-check-updates@19.3.2:
-    resolution: {integrity: sha512-9rr3z7znFjCSuaFxHGTFR2ZBOvLWaJcpLKmIquoTbDBNrwAGiHhv4MZyty6EJ9Xo/aMn35+2ISPSMgWIXx5Xkg==}
-    engines: {node: '>=20.0.0', npm: '>=8.12.1'}
+  npm-check-updates@22.2.9:
+    resolution: {integrity: sha512-DVeZ0KirHfliSsHuR2o7cHE+tW439sVHfJjF6cGWeDiY0Wyl3BI/jS4zV0eixtcMOquFbcF1Su/FsxOvk5MoYA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10.0.0'}
     hasBin: true
 
   npm-install-checks@7.1.1:
@@ -5832,11 +5832,12 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -10911,7 +10912,7 @@ snapshots:
     dependencies:
       npm-normalize-package-bin: 4.0.0
 
-  npm-check-updates@19.3.2: {}
+  npm-check-updates@22.2.9: {}
 
   npm-install-checks@7.1.1:
     dependencies:


### PR DESCRIPTION
Since v21 there is ESM support; updated config accordingly.

Since v20 the cooldown is taken from pnpm config; removed cooldown from ncu config.
