### PR TITLE
chore: move vercel configuration to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "pnpm run build",
-  "framework": "angular",
+  "framework": null,
   "outputDirectory": "dist/my-app",
   "git": {
     "deploymentEnabled": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm run build",
+  "framework": "angular",
+  "outputDirectory": "dist/my-app",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/*": false,
+      "gh-pages": false
+    }
+  }
+}


### PR DESCRIPTION
This PR moves the vercel configuration to `vercel.json`.

It is part of an effort to have all vercel configuration in Terraform.  Some settings should "move with the code" and these will be kept in `vercel.json`.
